### PR TITLE
fix: do not escape special characters before sending string packet properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "reflect-metadata": "^0.1.13",
     "supports-color": "^9.2.3",
     "tiny-typed-emitter": "^2.1.0",
-    "unicode-to-lfs": "^1.0.2"
+    "unicode-to-lfs": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.3",

--- a/src/__tests__/lfspack.test.ts
+++ b/src/__tests__/lfspack.test.ts
@@ -93,15 +93,19 @@ describe('lfspack', () => {
     });
   });
 
-  // Special case for strings
-  const buffer = [97, 98, 99, 32, 94, 69, 236, 154, 232, 0];
-  const format = '10s';
-  const values = ['abc ^Eì\x9Aè\0', 'abc ěšč'];
+  describe('strings', () => {
+    const buffer = [
+      97, 98, 99, 32, 94, 69, 236, 154, 232, 124, 42, 58, 92, 47, 63, 34, 60,
+      62, 35,
+    ];
+    const format = '19s';
+    const values = ['abc ^Eì\x9Aè|*:\\/?"<>#', 'abc ěšč|*:\\/?"<>#'];
 
-  it(`'${format}' should pack [${values}] into [${buffer}]`, () => {
-    expect(pack(format, [values[1]])).toEqual(new Uint8Array(buffer));
-  });
-  it(`'${format}' should unpack [${buffer}] into [${values}]`, () => {
-    expect(unpack(format, new Uint8Array(buffer).buffer)).toEqual([values]);
+    it(`'${format}' should pack [${values}] into [${buffer}]`, () => {
+      expect(pack(format, [values[1]])).toEqual(new Uint8Array(buffer));
+    });
+    it(`'${format}' should unpack [${buffer}] into [${values}]`, () => {
+      expect(unpack(format, new Uint8Array(buffer).buffer)).toEqual([values]);
+    });
   });
 });

--- a/src/packets/__tests__/IS_ISI.test.ts
+++ b/src/packets/__tests__/IS_ISI.test.ts
@@ -11,7 +11,7 @@ const data: IS_ISI_Data = {
   InSimVer: 9,
   Prefix: '!',
   Interval: 30,
-  Admin: 'adminadminadmin',
+  Admin: 'admin|*:\\/?"<>#',
   IName: 'app app app app',
 };
 
@@ -28,7 +28,7 @@ const buffer = new Uint8Array([
   '!'.charCodeAt(0), // Prefix
   30, // Interval (1)
   0, // Interval (2)
-  ...stringToBytes('adminadminadmin\0'), // Admin[16]
+  ...stringToBytes('admin|*:\\/?"<>#\0'), // Admin[16]
   ...stringToBytes('app app app app\0'), // IName[16]
 ]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5588,10 +5588,10 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
 
-unicode-to-lfs@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/unicode-to-lfs/-/unicode-to-lfs-1.0.2.tgz#5809dbac0677d2f4963c8ceaab3ed40bc0e28739"
-  integrity sha512-VWBnNlTcxR7HYtR80TzapJtmjnL4wC77kxyRuYi79eb8w3YWcCtFgFgi30yVb8rT+801FY4kByAM/i9ubOB/pg==
+unicode-to-lfs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/unicode-to-lfs/-/unicode-to-lfs-2.0.0.tgz#3abd1f161ef741da3d3df84d0206deb6cc1c86e9"
+  integrity sha512-5KHJgzDaQOPou5kgIoF3kSSRP9t2OkDScUb4yqZv7wpM2Tdufj7e00Bbb4K28O5LWh2IY3vwyctnu44hTmTEUQ==
 
 universalify@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
BREAKING CHANGE: Upgraded `unicode-to-lfs` to v2.0.0 which does not convert special characters into escape sequences anymore

Fixes #24
Fixes #22