### PR TITLE
fix(is_npl): change unpacked data type of CName to handle mod Skin IDs correctly

### DIFF
--- a/src/packets/IS_NPL.ts
+++ b/src/packets/IS_NPL.ts
@@ -1,4 +1,4 @@
-import { byte, string, stringNull, word } from '../decorators';
+import { byte, carName, string, stringNull, word } from '../decorators';
 import { Packet } from './base';
 import type {
   PassengerFlags,
@@ -37,8 +37,14 @@ export class IS_NPL extends Packet {
   /** Number plate - NO ZERO AT END! */
   @string(8) Plate = '';
 
-  /** Car name */
-  @stringNull(4) CName = '';
+  /**
+   * Car name
+   *
+   * The value can be one of these:
+   * - a 3-character abbreviation of an official LFS car (e.g. XRT)
+   * - a hexadecimal string representation of a car mod's SkinID (e.g. 5882E6)
+   **/
+  @carName() CName = '';
 
   /** Skin name - MAX_CAR_TEX_NAME */
   @stringNull(16) SName = '';

--- a/src/packets/__tests__/IS_NPL.test.ts
+++ b/src/packets/__tests__/IS_NPL.test.ts
@@ -17,70 +17,142 @@ const pName = "Player's name max length";
 const plate = 'Numplate';
 const sName = 'MAX_CAR_TEX_NAME';
 
-const data: PacketTestData<IS_NPL> = {
-  ReqI: 0,
-  PLID: 3,
-  UCID: 5,
-  PType: PlayerType.AI,
-  Flags: PlayerFlags.PIF_AUTOGEARS,
-  PName: pName,
-  Plate: plate,
-  CName: 'XRT',
-  SName: sName,
-  TyreRL: TyreCompound.TYRE_R1,
-  TyreRR: TyreCompound.TYRE_R2,
-  TyreFL: TyreCompound.TYRE_R3,
-  TyreFR: TyreCompound.TYRE_R4,
-  H_Mass: 10,
-  H_TRes: 15,
-  Model: 1,
-  Pass: PassengerFlags.FRONT_FEMALE,
-  RWAdj: 4,
-  FWAdj: 5,
-  SetF: SetupFlags.SETF_ABS_ENABLE,
-  NumP: 20,
-  Config: CarConfiguration.OPEN_ROOF_OR_ALTERNATE,
-  Fuel: 34,
-};
-
-const buffer = new Uint8Array([
-  size / new IS_NPL().SIZE_MULTIPLIER, // Size
-  21, // Type
-  0, // ReqI
-  3, // PLID
-  5, // UCID
-  2, // PType
-  8, // Flags (0)
-  0, // Flags (1)
-  ...stringToBytes(pName), // PName[24]
-  ...stringToBytes(plate), // Plate[8]
-  ...stringToBytes('XRT'), // CName[4]
-  0,
-  ...stringToBytes(sName), // SName[16]
-  0, // TyreRL
-  1, // TyreRR
-  2, // TyreFL
-  3, // TyreFR
-  10, // H_Mass
-  15, // H_TRes
-  1, // Model
-  2, // Pass
-  4, // RWAdj
-  5, // FWAdj
-  0, // Sp2
-  0, // Sp3
-  4, // SetF
-  20, // NumP
-  1, // Config
-  34, // Fuel
-]);
-
 describe('IS_NPL', () => {
-  testInfoPacket({
-    packetClass: IS_NPL,
-    size,
-    type: PacketType.ISP_NPL,
-    data,
-    buffer,
+  describe('official car', () => {
+    const data: PacketTestData<IS_NPL> = {
+      ReqI: 0,
+      PLID: 3,
+      UCID: 5,
+      PType: PlayerType.AI,
+      Flags: PlayerFlags.PIF_AUTOGEARS,
+      PName: pName,
+      Plate: plate,
+      CName: 'XRT',
+      SName: sName,
+      TyreRL: TyreCompound.TYRE_R1,
+      TyreRR: TyreCompound.TYRE_R2,
+      TyreFL: TyreCompound.TYRE_R3,
+      TyreFR: TyreCompound.TYRE_R4,
+      H_Mass: 10,
+      H_TRes: 15,
+      Model: 1,
+      Pass: PassengerFlags.FRONT_FEMALE,
+      RWAdj: 4,
+      FWAdj: 5,
+      SetF: SetupFlags.SETF_ABS_ENABLE,
+      NumP: 20,
+      Config: CarConfiguration.OPEN_ROOF_OR_ALTERNATE,
+      Fuel: 34,
+    };
+
+    const buffer = new Uint8Array([
+      size / new IS_NPL().SIZE_MULTIPLIER, // Size
+      21, // Type
+      0, // ReqI
+      3, // PLID
+      5, // UCID
+      2, // PType
+      8, // Flags (0)
+      0, // Flags (1)
+      ...stringToBytes(pName), // PName[24]
+      ...stringToBytes(plate), // Plate[8]
+      ...stringToBytes('XRT'), // CName[4]
+      0,
+      ...stringToBytes(sName), // SName[16]
+      0, // TyreRL
+      1, // TyreRR
+      2, // TyreFL
+      3, // TyreFR
+      10, // H_Mass
+      15, // H_TRes
+      1, // Model
+      2, // Pass
+      4, // RWAdj
+      5, // FWAdj
+      0, // Sp2
+      0, // Sp3
+      4, // SetF
+      20, // NumP
+      1, // Config
+      34, // Fuel
+    ]);
+
+    testInfoPacket({
+      packetClass: IS_NPL,
+      size,
+      type: PacketType.ISP_NPL,
+      data,
+      buffer,
+    });
+  });
+
+  describe('car mod', () => {
+    const data: PacketTestData<IS_NPL> = {
+      ReqI: 0,
+      PLID: 3,
+      UCID: 5,
+      PType: PlayerType.AI,
+      Flags: PlayerFlags.PIF_AUTOGEARS,
+      PName: pName,
+      Plate: plate,
+      CName: '5882E6',
+      SName: sName,
+      TyreRL: TyreCompound.TYRE_R1,
+      TyreRR: TyreCompound.TYRE_R2,
+      TyreFL: TyreCompound.TYRE_R3,
+      TyreFR: TyreCompound.TYRE_R4,
+      H_Mass: 10,
+      H_TRes: 15,
+      Model: 1,
+      Pass: PassengerFlags.FRONT_FEMALE,
+      RWAdj: 4,
+      FWAdj: 5,
+      SetF: SetupFlags.SETF_ABS_ENABLE,
+      NumP: 20,
+      Config: CarConfiguration.OPEN_ROOF_OR_ALTERNATE,
+      Fuel: 34,
+    };
+
+    const buffer = new Uint8Array([
+      size / new IS_NPL().SIZE_MULTIPLIER, // Size
+      21, // Type
+      0, // ReqI
+      3, // PLID
+      5, // UCID
+      2, // PType
+      8, // Flags (0)
+      0, // Flags (1)
+      ...stringToBytes(pName), // PName[24]
+      ...stringToBytes(plate), // Plate[8]
+      230, // CName (1)
+      130, // CName (2)
+      88, // CName (3)
+      0, // CName (4)
+      ...stringToBytes(sName), // SName[16]
+      0, // TyreRL
+      1, // TyreRR
+      2, // TyreFL
+      3, // TyreFR
+      10, // H_Mass
+      15, // H_TRes
+      1, // Model
+      2, // Pass
+      4, // RWAdj
+      5, // FWAdj
+      0, // Sp2
+      0, // Sp3
+      4, // SetF
+      20, // NumP
+      1, // Config
+      34, // Fuel
+    ]);
+
+    testInfoPacket({
+      packetClass: IS_NPL,
+      size,
+      type: PacketType.ISP_NPL,
+      data,
+      buffer,
+    });
   });
 });


### PR DESCRIPTION
Changed the decorator of `CName` property to `@carName()` which converts the Skin ID binary representation to a HEX string internally.

Added a unit test with a Skin ID.

fix #31