### PR TITLE
feat(insim): support connection via UDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ inSim2.connect({
 });
 ```
 
+#### TCP / UDP
+
+By default, Node InSim opens a TCP connection. If you want to use UDP,
+set the `Protocol` option to `UDP` in the `connect` function.
+
+```ts
+import { InSim } from 'node-insim';
+
+const inSim = new InSim();
+
+inSim.connect({
+  Host: '127.0.0.1',
+  Port: 29999,
+  IName: 'Node InSim App',
+  Protocol: 'UDP',
+});
+```
+
 ### Sending packets
 
 InSim packets can be sent using the `send()` method on the `InSim` class instance,

--- a/src/__tests__/TCP.test.ts
+++ b/src/__tests__/TCP.test.ts
@@ -1,6 +1,6 @@
 import Mitm from 'mitm';
 
-import { TCP } from '../protocols/TCP';
+import { TCP } from '../protocols';
 
 describe('TCP', () => {
   let mitm: ReturnType<typeof Mitm>;
@@ -27,7 +27,7 @@ describe('TCP', () => {
     });
 
     tcp.connect();
-    tcp.on('packet', (buffer: Uint8Array) => {
+    tcp.on('data', (buffer: Uint8Array) => {
       expect(buffer).toEqual(new Uint8Array([1, 3, 0, 0]));
       tcp.disconnect();
       done();
@@ -50,7 +50,7 @@ describe('TCP', () => {
     });
 
     tcp.connect();
-    tcp.on('packet', (buffer: Uint8Array) => {
+    tcp.on('data', (buffer: Uint8Array) => {
       expect(buffer).toEqual(new Uint8Array(packets[packetsReceived]));
 
       packetsReceived++;

--- a/src/out/OutGauge.ts
+++ b/src/out/OutGauge.ts
@@ -42,8 +42,13 @@ export class OutGauge extends TypedEmitter<OutGaugeEvents> {
 
     log(`Connecting to ${this._options.Host}:${this._options.Port}...`);
 
-    this.connection = new UDP(this.timeout);
-    this.connection.connect(this._options.Host, this._options.Port);
+    this.connection = new UDP({
+      host: this._options.Host,
+      port: this._options.Port,
+      timeout: this.timeout,
+      socketInitialisationMode: 'bind',
+    });
+    this.connection.connect();
 
     this.connection.on('connect', () => {
       this.emit('connect');
@@ -57,7 +62,7 @@ export class OutGauge extends TypedEmitter<OutGaugeEvents> {
       throw new InSimError(`UDP connection error: ${error.message}`);
     });
 
-    this.connection.on('message', (data) => this.handleMessage(data));
+    this.connection.on('data', (data) => this.handleMessage(data));
 
     this.connection.on('timeout', () => {
       this.emit('timeout');

--- a/src/out/OutSim.ts
+++ b/src/out/OutSim.ts
@@ -45,8 +45,13 @@ export class OutSim extends TypedEmitter<OutSimEvents> {
 
     log(`Connecting to ${this._options.Host}:${this._options.Port}...`);
 
-    this.connection = new UDP(this.timeout);
-    this.connection.connect(this._options.Host, this._options.Port);
+    this.connection = new UDP({
+      host: this._options.Host,
+      port: this._options.Port,
+      timeout: this.timeout,
+      socketInitialisationMode: 'bind',
+    });
+    this.connection.connect();
 
     this.connection.on('connect', () => {
       this.emit('connect');
@@ -60,7 +65,7 @@ export class OutSim extends TypedEmitter<OutSimEvents> {
       throw new InSimError(`UDP connection error: ${error.message}`);
     });
 
-    this.connection.on('message', (data) => this.handleMessage(data));
+    this.connection.on('data', (data) => this.handleMessage(data));
 
     this.connection.on('timeout', () => {
       this.emit('timeout');

--- a/src/protocols/Protocol.ts
+++ b/src/protocols/Protocol.ts
@@ -1,0 +1,37 @@
+import { TypedEmitter } from 'tiny-typed-emitter';
+
+type Events = {
+  connect: () => void;
+  disconnect: () => void;
+  data: (data: Uint8Array) => void;
+  error: (error: Error) => void;
+  timeout: () => void;
+};
+
+interface ProtocolOptions {
+  host: string;
+  port: number;
+  packetSizeMultiplier?: number;
+}
+
+/** @internal */
+export abstract class Protocol extends TypedEmitter<Events> {
+  protected readonly host: string;
+  protected readonly port: number;
+  protected readonly packetSizeMultiplier: number;
+
+  protected constructor({
+    host,
+    port,
+    packetSizeMultiplier = 1,
+  }: ProtocolOptions) {
+    super();
+    this.host = host;
+    this.port = port;
+    this.packetSizeMultiplier = packetSizeMultiplier;
+  }
+
+  abstract connect(): void;
+  abstract disconnect(): void;
+  abstract send(data: Uint8Array): void;
+}

--- a/src/protocols/index.ts
+++ b/src/protocols/index.ts
@@ -2,4 +2,7 @@
 export { TCP } from './TCP';
 
 /** @internal */
+export { Protocol } from './Protocol';
+
+/** @internal */
 export { UDP } from './UDP';


### PR DESCRIPTION
Added an InSim connection option `Protocol`, which can be either TCP or UDP. The default value is TCP.

fix #34

```js
const inSim = new InSim();

inSim.connect({
  IName: 'Node InSim App',
  Host: '127.0.0.1',
  Port: 29999,
  ReqI: IS_ISI_ReqI.SEND_VERSION,
  Admin: '',
  Protocol: 'UDP',
});
```