### PR TITLE
feat(insim): add `sendAwait` method

### DIFF
--- a/src/InSim.ts
+++ b/src/InSim.ts
@@ -309,9 +309,9 @@ export class InSim extends TypedEmitter<InSimEvents> {
   sendAwait = <TPacketTypeToAwait extends keyof typeof packetTypeToClass>(
     packet: SendablePacket,
     packetTypeToAwait: TPacketTypeToAwait,
-    filterPacketData?: (
+    filterPacketData: (
       packet: InSimPacketClassInstance<TPacketTypeToAwait>,
-    ) => boolean,
+    ) => boolean = () => true,
   ) => {
     return new Promise<InSimPacketClassInstance<TPacketTypeToAwait>>(
       (resolve, reject) => {
@@ -322,14 +322,11 @@ export class InSim extends TypedEmitter<InSimEvents> {
         }
 
         this.send(packet);
+
+        log('Await packet:', PacketType[packetTypeToAwait]);
         const packetListener = (
           receivedPacket: InSimPacketClassInstance<TPacketTypeToAwait>,
         ) => {
-          if (!filterPacketData) {
-            resolve(receivedPacket);
-            return;
-          }
-
           if (
             receivedPacket.ReqI === packet.ReqI &&
             filterPacketData(receivedPacket)
@@ -337,7 +334,6 @@ export class InSim extends TypedEmitter<InSimEvents> {
             resolve(receivedPacket);
           }
         };
-        log('Await packet:', PacketType[packetTypeToAwait]);
         this.once(packetTypeToAwait, packetListener);
 
         this.on('disconnect', () => {

--- a/src/InSim.ts
+++ b/src/InSim.ts
@@ -330,7 +330,10 @@ export class InSim extends TypedEmitter<InSimEvents> {
             return;
           }
 
-          if (filterPacketData(receivedPacket)) {
+          if (
+            receivedPacket.ReqI === packet.ReqI &&
+            filterPacketData(receivedPacket)
+          ) {
             resolve(receivedPacket);
           }
         };

--- a/src/InSim.ts
+++ b/src/InSim.ts
@@ -21,6 +21,7 @@ import {
   packetTypeToClass,
   TinyType,
 } from './packets';
+import type { InSimPacketClassInstance } from './packets/types';
 import type { Protocol } from './protocols';
 import { TCP, UDP } from './protocols';
 
@@ -302,6 +303,45 @@ export class InSim extends TypedEmitter<InSimEvents> {
         Text: message,
         Sound: sound,
       }),
+    );
+  };
+
+  sendAwait = <TPacketTypeToAwait extends keyof typeof packetTypeToClass>(
+    packet: SendablePacket,
+    packetTypeToAwait: TPacketTypeToAwait,
+    filterPacketData?: (
+      packet: InSimPacketClassInstance<TPacketTypeToAwait>,
+    ) => boolean,
+  ) => {
+    return new Promise<InSimPacketClassInstance<TPacketTypeToAwait>>(
+      (resolve, reject) => {
+        if (this.connection === null) {
+          log('Cannot send a packet with await - not connected');
+          reject();
+          return;
+        }
+
+        this.send(packet);
+        const packetListener = (
+          receivedPacket: InSimPacketClassInstance<TPacketTypeToAwait>,
+        ) => {
+          if (!filterPacketData) {
+            resolve(receivedPacket);
+            return;
+          }
+
+          if (filterPacketData(receivedPacket)) {
+            resolve(receivedPacket);
+          }
+        };
+        log('Await packet:', PacketType[packetTypeToAwait]);
+        this.once(packetTypeToAwait, packetListener);
+
+        this.on('disconnect', () => {
+          this.removeListener(packetTypeToAwait, packetListener);
+          reject();
+        });
+      },
     );
   };
 

--- a/src/InSimEvents.ts
+++ b/src/InSimEvents.ts
@@ -1,9 +1,11 @@
+import type { packetTypeToClass } from 'node-insim/packets';
+
 import type { InSim } from './InSim';
-import type { packetTypeToClass } from './packets';
+import type { InSimPacketClassInstance } from './packets/types';
 
 export type InSimPacketEvents = {
-  [k in keyof typeof packetTypeToClass]: (
-    packet: (typeof packetTypeToClass)[k]['prototype'],
+  [TPacketType in keyof typeof packetTypeToClass]: (
+    packet: InSimPacketClassInstance<TPacketType>,
     inSim: InSim,
   ) => void;
 };

--- a/src/packets/types/InSimPacket.ts
+++ b/src/packets/types/InSimPacket.ts
@@ -2,3 +2,7 @@ import type { packetTypeToClass } from '../index';
 
 export type InSimPacket =
   (typeof packetTypeToClass)[keyof typeof packetTypeToClass];
+
+export type InSimPacketClassInstance<
+  TPacketType extends keyof typeof packetTypeToClass,
+> = (typeof packetTypeToClass)[TPacketType]['prototype'];

--- a/src/packets/types/index.ts
+++ b/src/packets/types/index.ts
@@ -1,4 +1,4 @@
-export type { InSimPacket } from './InSimPacket';
+export type { InSimPacket, InSimPacketClassInstance } from './InSimPacket';
 export type {
   PacketData,
   PacketDataWithOptionalReqI,


### PR DESCRIPTION
## Syntax

```ts
inSim.sendAwait(packet, packetTypeToAwait, filterPacketData?) => Promise
```

## Examples

### Get session time

```ts
const sessionTime = await inSim.sendAwait(
  new IS_TINY({
    ReqI: 1,
    SubT: TinyType.TINY_GTH,
  }),
  PacketType.ISP_SMALL,
  ({ SubT }) => SubT === SmallType.SMALL_RTP,
);
```

### Ping

```ts
console.time('ping');
inSim.sendAwait(
  new IS_TINY({
    ReqI: 1,
    SubT: TinyType.TINY_PING,
  }),
  PacketType.ISP_TINY,
  packet => packet.ReqI === 1 && packet.SubT === TinyType.TINY_REPLY
).then(() => {
  console.timeEnd('ping'); // ping: 12.245ms
});
```