### PR TITLE
feat(insim): keep only packet properties in packet event listener callback parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,15 +265,14 @@ packets by their type.
 
 ```ts
 import { InSim } from 'node-insim';
-import type { IS_VER } from 'node-insim/packets';
-import { PacketType } from 'node-insim/packets';
+import { InSimPacketInstance, PacketType } from 'node-insim/packets';
 
 const inSim = new InSim();
 
 inSim.on(PacketType.ISP_VER, onVersion);
 
-function onVersion(packet: IS_VER) {
-  console.log(`Connected to LFS ${packet.product} ${packet.Version}`);
+function onVersion(packet: InSimPacketInstance<PacketType.ISP_VER>) {
+  console.log(`Connected to LFS ${packet.Product} ${packet.Version}`);
 }
 ```
 
@@ -283,14 +282,17 @@ additional packets in response.
 
 ```ts
 import { InSim } from 'node-insim';
-import { PacketType } from 'node-insim/packets';
-import type { IS_VER } from 'node-insim/packets';
+import { InSimPacketInstance, PacketType, TinyType } from 'node-insim/packets';
+import type { IS_TINY } from 'node-insim/packets';
 
 const inSim = new InSim();
 
 inSim.on(PacketType.ISP_VER, onVersion);
 
-function onVersion(packet: IS_VER, inSim: InSim) {
+function onVersion(
+  packet: InSimPacketInstance<PacketType.ISP_VER>,
+  inSim: InSim,
+) {
   inSim.send(
     new IS_TINY({
       ReqI: 1,
@@ -310,6 +312,7 @@ can also be used to tell apart the InSim connections.
 
 ```ts
 import { InSim } from 'node-insim';
+import { InSimPacketInstance, PacketType } from 'node-insim/packets';
 
 const inSim1 = new InSim('Host One');
 
@@ -330,7 +333,10 @@ inSim2.connect({
 inSim1.on(PacketType.ISP_VER, onVersion);
 inSim2.on(PacketType.ISP_VER, onVersion);
 
-function onVersion(packet: IS_VER, inSim: InSim) {
+function onVersion(
+  packet: InSimPacketInstance<PacketType.ISP_VER>,
+  inSim: InSim,
+) {
   console.log(`Connected to ${inSim.options.Host}:${inSim.options.Port}`);
 
   if (inSim.id) {
@@ -350,11 +356,10 @@ property in the packet instance, which contains all unconverted string propertie
 ```ts
 import { InSim } from 'node-insim';
 import { PacketType } from 'node-insim/packets';
-import type { IS_ISM } from 'node-insim/packets';
 
 const inSim = new InSim();
 
-inSim.on(PacketType.ISP_ISM, (packet: IS_ISM) => {
+inSim.on(PacketType.ISP_ISM, (packet) => {
   console.log(packet.HName); // UTF-8 string - ^1Drifter Team ^7★ Server
   console.log(packet._raw.HName); // raw string - ^1Drifter Team ^7^J Server\u0000\u0000\u0000\u0000
 });
@@ -370,7 +375,7 @@ import type { IS_MSL } from 'node-insim/packets';
 
 const inSim = new InSim();
 
-inSim.on(PacketType.ISP_VER, (packet: IS_VER) => {
+inSim.on(PacketType.ISP_VER, (packet) => {
   inSim.send(
     new IS_MSL({
       Msg: 'čau světe', // LFS will receive: ^Eèau svìte
@@ -389,7 +394,7 @@ Special care needs to be taken when sending strings containing caret (`^`) and s
 ### OutGauge
 
 ```ts
-import { OutGauge, OutGaugePack } from 'node-insim';
+import { OutGauge } from 'node-insim';
 
 const outGauge = new OutGauge();
 
@@ -398,7 +403,7 @@ outGauge.connect({
   Port: 29999,
 });
 
-outGauge.on('packet', (data: OutGaugePack) => {
+outGauge.on('packet', (data) => {
   console.clear();
   console.log(data.RPM);
 });

--- a/src/InSim.ts
+++ b/src/InSim.ts
@@ -21,7 +21,7 @@ import {
   packetTypeToClass,
   TinyType,
 } from './packets';
-import type { InSimPacketClassInstance } from './packets/types';
+import type { InSimPacketInstance } from './packets/types';
 import type { Protocol } from './protocols';
 import { TCP, UDP } from './protocols';
 
@@ -245,10 +245,10 @@ export class InSim extends TypedEmitter<InSimEvents> {
     packet: SendablePacket,
     packetTypeToAwait: TPacketTypeToAwait,
     filterPacketData: (
-      packet: InSimPacketClassInstance<TPacketTypeToAwait>,
+      packet: InSimPacketInstance<TPacketTypeToAwait>,
     ) => boolean = () => true,
   ) => {
-    return new Promise<InSimPacketClassInstance<TPacketTypeToAwait>>(
+    return new Promise<InSimPacketInstance<TPacketTypeToAwait>>(
       (resolve, reject) => {
         if (this.connection === null) {
           log('Cannot send a packet with await - not connected');
@@ -260,7 +260,7 @@ export class InSim extends TypedEmitter<InSimEvents> {
 
         log('Await packet:', PacketType[packetTypeToAwait]);
         const packetListener = (
-          receivedPacket: InSimPacketClassInstance<TPacketTypeToAwait>,
+          receivedPacket: InSimPacketInstance<TPacketTypeToAwait>,
         ) => {
           if (
             receivedPacket.ReqI === packet.ReqI &&
@@ -309,7 +309,9 @@ export class InSim extends TypedEmitter<InSimEvents> {
     this.emit(packetType, packetInstance.unpack(data) as never, this);
   };
 
-  private handleKeepAlive = (packet: IS_TINY) => {
+  private handleKeepAlive = (
+    packet: InSimPacketInstance<PacketType.ISP_TINY>,
+  ) => {
     if (packet.SubT === TinyType.TINY_NONE) {
       this.send(
         new IS_TINY({

--- a/src/InSimEvents.ts
+++ b/src/InSimEvents.ts
@@ -1,11 +1,11 @@
 import type { packetTypeToClass } from 'node-insim/packets';
 
 import type { InSim } from './InSim';
-import type { InSimPacketClassInstance } from './packets/types';
+import type { InSimPacketInstance } from './packets/types';
 
 export type InSimPacketEvents = {
   [TPacketType in keyof typeof packetTypeToClass]: (
-    packet: InSimPacketClassInstance<TPacketType>,
+    packet: InSimPacketInstance<TPacketType>,
     inSim: InSim,
   ) => void;
 };

--- a/src/packets/base/Struct.ts
+++ b/src/packets/base/Struct.ts
@@ -8,7 +8,7 @@ const log = baseLog.extend('struct');
 
 type Data = Record<string, unknown>;
 
-type RawProperties<TThis> = {
+export type RawProperties<TThis> = {
   [P in keyof Omit<TThis, keyof Struct>]: TThis[P];
 };
 

--- a/src/packets/index.ts
+++ b/src/packets/index.ts
@@ -307,4 +307,4 @@ export {
   ObjectInfo,
   PlayerHCap,
 } from './structs';
-export type { InSimPacket } from './types';
+export type { InSimPacket, InSimPacketInstance } from './types';

--- a/src/packets/types/InSimPacket.ts
+++ b/src/packets/types/InSimPacket.ts
@@ -1,8 +1,16 @@
+import type { RawProperties } from '../base/Struct';
 import type { packetTypeToClass } from '../index';
+import type { ReadonlyPropNames } from './StructData';
 
-export type InSimPacket =
-  (typeof packetTypeToClass)[keyof typeof packetTypeToClass];
+type InSimPacketByType<T extends keyof typeof packetTypeToClass> =
+  (typeof packetTypeToClass)[T];
 
-export type InSimPacketClassInstance<
+export type InSimPacket = InSimPacketByType<keyof typeof packetTypeToClass>;
+
+export type InSimPacketInstance<
   TPacketType extends keyof typeof packetTypeToClass,
-> = (typeof packetTypeToClass)[TPacketType]['prototype'];
+> = Omit<
+  RawProperties<InSimPacketByType<TPacketType>['prototype']>,
+  ReadonlyPropNames
+> &
+  Pick<InSimPacketByType<TPacketType>['prototype'], '_raw'>;

--- a/src/packets/types/index.ts
+++ b/src/packets/types/index.ts
@@ -1,4 +1,4 @@
-export type { InSimPacket, InSimPacketClassInstance } from './InSimPacket';
+export type { InSimPacket, InSimPacketInstance } from './InSimPacket';
 export type {
   PacketData,
   PacketDataWithOptionalReqI,


### PR DESCRIPTION
The parameter is now typed as `InSimPacketInstance<T>` where T is one of `PacketType` enum values. This helper type is now exported from `node-insim/packets`.

BREAKING CHANGE: The type of the `packet` parameter in the InSim event handler callback is now restricted to the packet properties. The following properties have been removed from the output type: `getFormat`, `getFormatSize`, `getValidPropertyNames`, `pack`, `unpack`, as well as all read-only packet properties `Zero`, `Spare`, `Spare1`, `Spare2`, `Spare3`, `Sp0`, `Sp1`, `Sp2`, `Sp3`.

## API changes

For named callback functions, the `packet` parameter type will have to be updated.

Before:

```ts
import { InSim } from 'node-insim';
import { PacketType } from 'node-insim/packets';
import type { IS_VER } from 'node-insim/packets';

const inSim = new InSim();

inSim.on(PacketType.ISP_VER, onVersion);

function onVersion(packet: IS_VER, inSim: InSim) {
  inSim.send(
    new IS_TINY({
      ReqI: 1,
      SubT: TinyType.TINY_PING,
    }),
  );
}
```

After:

```ts
import { InSim } from 'node-insim';
import { InSimPacketInstance, PacketType, TinyType } from 'node-insim/packets';
import type { IS_TINY } from 'node-insim/packets';

const inSim = new InSim();

inSim.on(PacketType.ISP_VER, onVersion);

function onVersion(
  packet: InSimPacketInstance<PacketType.ISP_VER>,
  inSim: InSim,
) {
  inSim.send(
    new IS_TINY({
      ReqI: 1,
      SubT: TinyType.TINY_PING,
    }),
  );
}
```

Fixes #70